### PR TITLE
[nao_gazebo_plugin/README.rst] clone using https

### DIFF
--- a/nao_gazebo_plugin/README.rst
+++ b/nao_gazebo_plugin/README.rst
@@ -10,7 +10,7 @@ This packages requires several plugins that you have to fetch on github and comp
 
 .. code-block:: bash
     
-    git clone git@github.com:roboticsgroup/roboticsgroup_gazebo_plugins.git
+    git clone https://github.com/roboticsgroup/roboticsgroup_gazebo_plugins.git
     catkin_make
 
 Please also make sure that the package and all the dependencies are up to date


### PR DESCRIPTION
I'm investigating getting these packages built/working on kinetic. We should be able to remove totally dependency on roboticsgroup_gazebo_plugins in the near future. This is just a quick fix to address issues like https://github.com/ros-naoqi/pepper_virtual/issues/8#issue-196955822