### PR TITLE
Remove pal packages dependencies

### DIFF
--- a/nao_gazebo_plugin/README.rst
+++ b/nao_gazebo_plugin/README.rst
@@ -11,8 +11,6 @@ This packages requires several plugins that you have to fetch on github and comp
 .. code-block:: bash
 
     git clone https://github.com/roboticsgroup/roboticsgroup_gazebo_plugins.git
-    git clone https://github.com/pal-robotics/pal_msgs.git
-    git clone https://github.com/pal-robotics/pal_gazebo_plugins.git
     catkin_make
 
 Please also make sure that the package and all the dependencies are up to date

--- a/nao_gazebo_plugin/nao.rosinstall
+++ b/nao_gazebo_plugin/nao.rosinstall
@@ -25,8 +25,6 @@
 - git: {local-name: nao_virtual, uri: 'https://github.com/ros-naoqi/nao_virtual'}
 # Which depends on
 - git: {local-name: roboticsgroup_gazebo_plugins, uri: 'https://github.com/roboticsgroup/roboticsgroup_gazebo_plugins'}
-- git: {local-name: pal_msgs, uri: 'https://github.com/pal-robotics/pal_msgs'}
-- git: {local-name: pal_gazebo_plugins, uri: 'https://github.com/pal-robotics/pal_gazebo_plugins'}
 
 # Meshes stuff
 - git: {local-name: nao_meshes_installer, uri: 'https://github.com/ros-naoqi/nao_meshes_installer'}


### PR DESCRIPTION
As  discussed in https://github.com/ros-naoqi/nao_virtual/issues/17 these dependencies are not used anymore.

As the README doesnt specify to install the dependencies of these packages, users fail to build when following the README (see https://answers.ros.org/question/281671). 